### PR TITLE
Fix generator for Rails 5 (compatible with older rails, just renaming of method)

### DIFF
--- a/lib/generators/docsplit_images/docsplit_images_generator.rb
+++ b/lib/generators/docsplit_images/docsplit_images_generator.rb
@@ -23,6 +23,6 @@ class DocsplitImagesGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_class_name
-    migration_name.camelize
+    docsplut_images_migration_name.camelize
   end
 end

--- a/lib/generators/docsplit_images/docsplit_images_generator.rb
+++ b/lib/generators/docsplit_images/docsplit_images_generator.rb
@@ -23,6 +23,6 @@ class DocsplitImagesGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_class_name
-    docsplut_images_migration_name.camelize
+    docsplit_images_migration_name.camelize
   end
 end

--- a/lib/generators/docsplit_images/docsplit_images_generator.rb
+++ b/lib/generators/docsplit_images/docsplit_images_generator.rb
@@ -9,17 +9,17 @@ class DocsplitImagesGenerator < ActiveRecord::Generators::Base
   end
 
   def generate_migration
-    migration_template "docsplit_images_migration.rb.erb", "db/migrate/#{migration_file_name}"
+    migration_template "docsplit_images_migration.rb.erb", "db/migrate/#{docsplit_images_migration_file_name}"
   end
 
   protected
 
-  def migration_name
+  def docsplit_images_migration_name
     "add_docsplit_images_attribute_to_#{name.underscore.pluralize}"
   end
 
-  def migration_file_name
-    "#{migration_name}.rb"
+  def docsplit_images_migration_filename
+    "#{docsplit_images_migration_name}.rb"
   end
 
   def migration_class_name

--- a/lib/generators/docsplit_images/docsplit_images_generator.rb
+++ b/lib/generators/docsplit_images/docsplit_images_generator.rb
@@ -18,7 +18,7 @@ class DocsplitImagesGenerator < ActiveRecord::Generators::Base
     "add_docsplit_images_attribute_to_#{name.underscore.pluralize}"
   end
 
-  def docsplit_images_migration_filename
+  def docsplit_images_migration_file_name
     "#{docsplit_images_migration_name}.rb"
   end
 


### PR DESCRIPTION
When running:

`rails g docsplit_images <table_name> <attachment_field_name>`

There will be an error with:
`'migration_file_name': protected method 'migration_file_name' called for #<DocsplitImagesGenerator:0x007ff373be6090> (NoMethodError)`

It seems that `migration_file_name` is a method reserved in rails 5. I had renamed the appropriate methods to use docsplit_images_ to make it unique. (for example `docsplit_images_migration_file_name`)
