### PR TITLE
Upgrade docsplit and fix race condition with after_commit callback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :development do
 end
 
 gem 'paperclip', '>= 3.1.0'
-gem 'docsplit', '0.6.4'
+gem 'docsplit', '0.7.6'
 gem 'sidekiq', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     cocaine (0.5.5)
       climate_control (>= 0.0.3, < 1.0)
     connection_pool (2.1.0)
-    docsplit (0.6.4)
+    docsplit (0.7.6)
     git (1.2.8)
     hitimes (1.2.2)
     i18n (0.7.0)
@@ -58,9 +58,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  docsplit (= 0.6.4)
+  docsplit (= 0.7.6)
   jeweler (~> 1.8.4)
   paperclip (>= 3.1.0)
   rdoc (~> 3.12)
   shoulda
   sidekiq (>= 3.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/README.markdown
+++ b/README.markdown
@@ -50,13 +50,13 @@ aptitude install pdftk
 	
 On the Mac, you can download a [http://www.pdflabs.com/docs/install-pdftk/](recent installer for the binary). Without pdftk installed, you can use Docsplit, but won't be able to split apart a multi-page PDF into single-page PDFs. 
 
-#### 6. (Optional) Install OpenOffice. On Linux, use aptitude, apt-get or yum:
+#### 6. (Optional) Install LibreOffice. On Linux, use aptitude, apt-get or yum:
   
 ```bash
-aptitude install openoffice.org openoffice.org-java-common
+aptitude install libreoffice
 ```  
 
-On Mac, download and install [http://www.openoffice.org/download/index.html](http://www.openoffice.org/download/index.html).
+On Mac, download and install [http://www.libreoffice.org/download](http://www.libreoffice.org/download).
 
 ### Install Gem
 
@@ -91,7 +91,7 @@ docsplit_images requires sidekiq to be turned on the process.
 
 	[bundle exec] sidekiq
 
-While it is processing using [https://github.com/collectiveidea/delayed_job](delayed_job), you can check if it is processing by accessing attribute ``is_processing_image``
+While it is processing using [https://github.com/mperham/sidekiq](sidekiq), you can check if it is processing by accessing attribute ``is_processing_image``
 
 ```ruby
 asset.is_processing_image?

--- a/docsplit_images.gemspec
+++ b/docsplit_images.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_runtime_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_runtime_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_runtime_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
     else
       s.add_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -4,7 +4,11 @@ module DocsplitImages
     def self.included(base)
       
       base.before_save :check_for_file_change
-      base.after_commit :docsplit_images
+      if Rails::VERSION::MAJOR >= 5
+        base.after_comit :docsplit_images
+      else
+        base.after_save :docsplit_images
+      end
       
       def check_for_file_change
         @file_has_changed = self.send(self.class.docsplit_attachment_name).dirty?

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -5,7 +5,7 @@ module DocsplitImages
       
       base.before_save :check_for_file_change
       if Rails::VERSION::MAJOR >= 5
-        base.after_comit :docsplit_images
+        base.after_commit :docsplit_images
       else
         base.after_save :docsplit_images
       end

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -4,7 +4,7 @@ module DocsplitImages
     def self.included(base)
       
       base.before_save :check_for_file_change
-      base.after_save :docsplit_images
+      base.after_commit :docsplit_images
       
       def check_for_file_change
         @file_has_changed = self.send(self.class.docsplit_attachment_name).dirty?

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -4,11 +4,7 @@ module DocsplitImages
     def self.included(base)
       
       base.before_save :check_for_file_change
-      if Rails::VERSION::MAJOR >= 5
-        base.after_commit :docsplit_images
-      else
-        base.after_save :docsplit_images
-      end
+      base.after_commit :docsplit_images
       
       def check_for_file_change
         @file_has_changed = self.send(self.class.docsplit_attachment_name).dirty?


### PR DESCRIPTION
1. Update the gem to use docsplit 0.7.6. OpenOffice is no longer supported in the latest docsplit 0.7.6 gem which is good because we directly call LibreOffice instead of JODConverter.jar to convert doc/docx files to image and it is faster than OpenOffice because LibreOffice does lazy-load that makes subsequent conversion of the same file, faster.
2. Fix a race condition which is a problem documented here: `https://github.com/mperham/sidekiq/wiki/FAQ#why-am-i-seeing-a-lot-of-cant-find-modelname-with-id12345-errors-with-sidekiq`.
   This fixes the problem of having `Nil error` when docsplit_images tries to convert a document and as it tries query the `id` in DB (as per `perform_async`) but since sidekiq runs faster than the DB insert due to transactions and results in `Nil error` since the new record with the id is not seen by sidekiq.

[more info on transactions and after_commit here](http://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/)
