### PR TITLE
Update documenation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :development do
 end
 
 gem 'paperclip', '>= 3.1.0'
-gem 'docsplit', '0.6.4'
+gem 'docsplit', '0.7.6'
 gem 'sidekiq', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     cocaine (0.5.5)
       climate_control (>= 0.0.3, < 1.0)
     connection_pool (2.1.0)
-    docsplit (0.6.4)
+    docsplit (0.7.6)
     git (1.2.8)
     hitimes (1.2.2)
     i18n (0.7.0)
@@ -58,9 +58,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  docsplit (= 0.6.4)
+  docsplit (= 0.7.6)
   jeweler (~> 1.8.4)
   paperclip (>= 3.1.0)
   rdoc (~> 3.12)
   shoulda
   sidekiq (>= 3.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/README.markdown
+++ b/README.markdown
@@ -50,13 +50,13 @@ aptitude install pdftk
 	
 On the Mac, you can download a [http://www.pdflabs.com/docs/install-pdftk/](recent installer for the binary). Without pdftk installed, you can use Docsplit, but won't be able to split apart a multi-page PDF into single-page PDFs. 
 
-#### 6. (Optional) Install OpenOffice. On Linux, use aptitude, apt-get or yum:
+#### 6. (Optional) Install LibreOffice. On Linux, use aptitude, apt-get or yum:
   
 ```bash
-aptitude install openoffice.org openoffice.org-java-common
+aptitude install libreoffice
 ```  
 
-On Mac, download and install [http://www.openoffice.org/download/index.html](http://www.openoffice.org/download/index.html).
+On Mac, download and install [http://www.libreoffice.org/download](http://www.libreoffice.org/download).
 
 ### Install Gem
 
@@ -91,7 +91,7 @@ docsplit_images requires sidekiq to be turned on the process.
 
 	[bundle exec] sidekiq
 
-While it is processing using [https://github.com/collectiveidea/delayed_job](delayed_job), you can check if it is processing by accessing attribute ``is_processing_image``
+While it is processing using [https://github.com/mperham/sidekiq](sidekiq), you can check if it is processing by accessing attribute ``is_processing_image``
 
 ```ruby
 asset.is_processing_image?

--- a/docsplit_images.gemspec
+++ b/docsplit_images.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_runtime_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_runtime_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_runtime_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
     else
       s.add_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -4,7 +4,7 @@ module DocsplitImages
     def self.included(base)
       
       base.before_save :check_for_file_change
-      base.after_save :docsplit_images
+      base.after_commit :docsplit_images
       
       def check_for_file_change
         @file_has_changed = self.send(self.class.docsplit_attachment_name).dirty?


### PR DESCRIPTION
The latest update of the gem uses docsplit 0.7.6 which no longer work with OpenOffice for performance reasons.

LibreOffice so it is faster to convert from .doc files instead of the old OpenOffice JODConverter.jar - updated documentation to reflect on this.

Update the documentation since we are using sidekiq and not delayed_job anymore.