### PR TITLE
use downcase since casecmp won't work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :development do
 end
 
 gem 'paperclip', '>= 3.1.0'
-gem 'docsplit', '0.6.4'
+gem 'docsplit', '0.7.6'
 gem 'sidekiq', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     cocaine (0.5.5)
       climate_control (>= 0.0.3, < 1.0)
     connection_pool (2.1.0)
-    docsplit (0.6.4)
+    docsplit (0.7.6)
     git (1.2.8)
     hitimes (1.2.2)
     i18n (0.7.0)
@@ -58,9 +58,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  docsplit (= 0.6.4)
+  docsplit (= 0.7.6)
   jeweler (~> 1.8.4)
   paperclip (>= 3.1.0)
   rdoc (~> 3.12)
   shoulda
   sidekiq (>= 3.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/README.markdown
+++ b/README.markdown
@@ -50,13 +50,13 @@ aptitude install pdftk
 	
 On the Mac, you can download a [http://www.pdflabs.com/docs/install-pdftk/](recent installer for the binary). Without pdftk installed, you can use Docsplit, but won't be able to split apart a multi-page PDF into single-page PDFs. 
 
-#### 6. (Optional) Install OpenOffice. On Linux, use aptitude, apt-get or yum:
+#### 6. (Optional) Install LibreOffice. On Linux, use aptitude, apt-get or yum:
   
 ```bash
-aptitude install openoffice.org openoffice.org-java-common
+aptitude install libreoffice
 ```  
 
-On Mac, download and install [http://www.openoffice.org/download/index.html](http://www.openoffice.org/download/index.html).
+On Mac, download and install [http://www.libreoffice.org/download](http://www.libreoffice.org/download).
 
 ### Install Gem
 
@@ -91,7 +91,7 @@ docsplit_images requires sidekiq to be turned on the process.
 
 	[bundle exec] sidekiq
 
-While it is processing using [https://github.com/collectiveidea/delayed_job](delayed_job), you can check if it is processing by accessing attribute ``is_processing_image``
+While it is processing using [https://github.com/mperham/sidekiq](sidekiq), you can check if it is processing by accessing attribute ``is_processing_image``
 
 ```ruby
 asset.is_processing_image?

--- a/docsplit_images.gemspec
+++ b/docsplit_images.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_runtime_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_runtime_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_runtime_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
     else
       s.add_dependency(%q<paperclip>, [">= 3.1.0"])
-      s.add_dependency(%q<docsplit>, ["= 0.6.4"])
+      s.add_dependency(%q<docsplit>, ["= 0.7.6"])
       s.add_dependency(%q<sidekiq>, [">= 3.3.0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -46,9 +46,9 @@ module DocsplitImages
       # Going to convert to images
       Docsplit::ImageExtractor.new.extract(
         temp_pdf_path,
-        self.class.docsplit_attachment_options.merge(
+        self.class.docsplit_attachment_options.merge({
           output: "#{parent_dir}/images"
-        )
+        })
       )
 
       @file_has_changed = false

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -26,7 +26,7 @@ module DocsplitImages
       FileUtils.mkdir("#{parent_dir}/images")
       doc_path = self.send(self.class.docsplit_attachment_name).path
       ext = File.extname(doc_path)
-      temp_pdf_path = if ext.casecmp('pdf')
+      temp_pdf_path = if ext.downcase == '.pdf'
         doc_path
       else
         tempdir = File.join(Dir.tmpdir, 'docsplit')

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -41,6 +41,8 @@ module DocsplitImages
        @file_has_changed = false
       self.is_processing_image = false
       self.save(:validate => false)
+
+      after_docspliting
     end
 
     def after_docspliting

--- a/lib/docsplit_images/conversion.rb
+++ b/lib/docsplit_images/conversion.rb
@@ -26,7 +26,7 @@ module DocsplitImages
       FileUtils.mkdir("#{parent_dir}/images")
       doc_path = self.send(self.class.docsplit_attachment_name).path
       ext = File.extname(doc_path)
-      temp_pdf_path = if ext.downcase == '.pdf'
+      temp_pdf_path = if ext.casecmp('pdf')
         doc_path
       else
         tempdir = File.join(Dir.tmpdir, 'docsplit')


### PR DESCRIPTION
This PR reverts the casecmp back to use downcase as casecmp will result in the error with graphicsmagick command, "gm"